### PR TITLE
Errorz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+test.txt

--- a/src/bifs/math.rs
+++ b/src/bifs/math.rs
@@ -1,6 +1,7 @@
 use super::{
   V,
   Vstack,
+  Thread,
   Error,
   p_err,
   ptyp_err,
@@ -36,24 +37,25 @@ where
   }
 }
 
-pub fn add(stk:&mut Vstack) -> Result<(),Error> {
-  two_op(stk,|i1,i2|i1+i2,|f1,f2|f1+f2)
+pub fn add(th:&mut Thread) -> Result<(),Error> {
+  two_op(th.stk(),|i1,i2|i1+i2,|f1,f2|f1+f2)
 }
 
-pub fn sub(stk:&mut Vstack) -> Result<(),Error> {
-  two_op(stk,|i1,i2|i1-i2,|f1,f2|f1-f2)
+pub fn sub(th:&mut Thread) -> Result<(),Error> {
+  two_op(th.stk(),|i1,i2|i1-i2,|f1,f2|f1-f2)
 }
 
-pub fn mul(stk:&mut Vstack) -> Result<(),Error> {
-  two_op(stk,|i1,i2|i1*i2,|f1,f2|f1*f2)
+pub fn mul(th:&mut Thread) -> Result<(),Error> {
+  two_op(th.stk(),|i1,i2|i1*i2,|f1,f2|f1*f2)
 }
 
-pub fn div(stk:&mut Vstack) -> Result<(),Error> {
-  two_op(stk,|i1,i2|i1/i2,|f1,f2|f1/f2)
+pub fn div(th:&mut Thread) -> Result<(),Error> {
+  two_op(th.stk(),|i1,i2|i1/i2,|f1,f2|f1/f2)
 }
 
 //for the booleans
-pub fn eq(stk:&mut Vstack) -> Result<(),Error> {
+pub fn eq(th:&mut Thread) -> Result<(),Error> {
+  let stk = th.stk();
   let a = stk.pop().map_err(p_err("a"))?;
   let b = stk.pop().map_err(p_err("b"))?;
   stk.push(a==b);
@@ -61,10 +63,28 @@ pub fn eq(stk:&mut Vstack) -> Result<(),Error> {
   Ok(())
 }
 
-pub fn neq(stk:&mut Vstack) -> Result<(),Error> {
+pub fn neq(th:&mut Thread) -> Result<(),Error> {
+  let stk = th.stk();
   let a = stk.pop().map_err(p_err("a"))?;
   let b = stk.pop().map_err(p_err("b"))?;
   stk.push(a != b);
 
+  Ok(())
+}
+
+pub fn to_int(th:&mut Thread) -> Result<(),Error> {
+  let stk = th.stk();
+  let a = stk.pop().map_err(p_err("a"))?;
+  let b = stk.pop().map_err(p_err("b"))?;
+  stk.push(a != b);
+
+  Ok(())
+}
+
+pub fn to_float(th:&mut Thread) -> Result<(),Error> {
+  let stk = th.stk();
+  let a = stk.tpop::<i64>().map_err(p_err("a"))?;
+  let z :f64 = a as f64;
+  stk.push(z);
   Ok(())
 }

--- a/src/bifs/mod.rs
+++ b/src/bifs/mod.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use crate::{
   V,
   F,
+  Thread,
   functions::BifPtr,
   Vstack,
   StackErr
@@ -39,19 +40,26 @@ pub fn root_dict() -> std::collections::HashMap<Arc<str>,F> {
     def("if","ifTrue(fn) ifFalse(fn) c(B) --> (one of the 2 functions)",functional::cond),
     def("while","body (fn --> whatever) test(fn ? --> bool)",functional::while_loop),
 
-    def("doc","prints a bif's documentation",util::doc)
+    def(".","prints the current state of the thread",util::print),
+    def("doc","prints a bif's documentation",util::doc),
+    def("do_file","loads a file in a spare thread then applys it",util::do_file),
+    def("I","Z --> I(rounded)",math::to_int),
+    def("Z","I --> Z",math::to_float),
   ])
 }
 
 #[derive(Debug,Copy,Clone)]
 pub enum Error {
-  Param(&'static str,StackErr)
+  Param(&'static str,StackErr),
+  Internal(&'static str)
 }
 
 impl std::fmt::Display for Error {
   fn fmt(&self,f:&mut std::fmt::Formatter) -> Result<(),std::fmt::Error> {
-    let Error::Param(pname,root) = self;
-    write!(f,"parameter error on param:{pname}, cause:{root}")
+    match self {
+      Error::Param(pname,root) => write!(f,"parameter error on param:{pname}, cause:{root}"),
+      Error::Internal(msg) => write!(f,"internal error {msg}")
+    }
   }
 }
 

--- a/src/bifs/stack.rs
+++ b/src/bifs/stack.rs
@@ -1,17 +1,18 @@
 use super::{
-  Vstack,
-  Error,
-  //err
+  Thread,
+  Error
 };
 
-pub fn dup(stk:&mut Vstack) -> Result<(),Error> {
+pub fn dup(th:&mut Thread) -> Result<(),Error> {
+  let stk = th.stk();
   let v = stk.pop().map_err(|se|Error::Param("a",se))?;
   stk.push(v.clone());
   stk.push(v.clone());
   Ok(())
 }
 
-pub fn over(stk:&mut Vstack) -> Result<(),Error> {
+pub fn over(th:&mut Thread) -> Result<(),Error> {
+  let stk = th.stk();
   let b = stk.pop().map_err(|se|Error::Param("b",se))?;
   let a = stk.pop().map_err(|se|Error::Param("a",se))?;
   let ac = a.clone();
@@ -21,7 +22,8 @@ pub fn over(stk:&mut Vstack) -> Result<(),Error> {
   Ok(())
 }
 
-pub fn swap(stk:&mut Vstack) -> Result<(),Error> {
+pub fn swap(th:&mut Thread) -> Result<(),Error> {
+  let stk = th.stk();
   let b = stk.pop().map_err(|se|Error::Param("b",se))?;
   let a = stk.pop().map_err(|se|Error::Param("a",se))?;
   stk.push(b);
@@ -29,7 +31,8 @@ pub fn swap(stk:&mut Vstack) -> Result<(),Error> {
   Ok(())
 }
 
-pub fn rot(stk:&mut Vstack) -> Result<(),Error> {
+pub fn rot(th:&mut Thread) -> Result<(),Error> {
+  let stk = th.stk();
   let c = stk.pop().map_err(|se|Error::Param("c",se))?;
   let b = stk.pop().map_err(|se|Error::Param("b",se))?;
   let a = stk.pop().map_err(|se|Error::Param("a",se))?;
@@ -39,12 +42,13 @@ pub fn rot(stk:&mut Vstack) -> Result<(),Error> {
   Ok(())
 }
 
-pub fn drop(stk:&mut Vstack) -> Result<(),Error> {
+pub fn drop(th:&mut Thread) -> Result<(),Error> {
+  let stk = th.stk();
   let _ = stk.pop();
   Ok(())
 }
 
-pub fn clear(stk:&mut Vstack) -> Result<(),Error> {
-  stk.clear();
+pub fn clear(th:&mut Thread) -> Result<(),Error> {
+  th.stk().clear();
   Ok(())
 }

--- a/src/bifs/util.rs
+++ b/src/bifs/util.rs
@@ -1,11 +1,10 @@
 use super::{
-  Vstack,
+  Thread,
   Error,
   p_err,
   F,
   V
 };
-
 
 fn print_vs(vs:&[V]) {
   if vs.is_empty() {
@@ -20,7 +19,8 @@ fn print_vs(vs:&[V]) {
   }
 }
 
-pub fn doc(stk:&mut Vstack) -> Result<(),Error> {
+pub fn doc(th:&mut Thread) -> Result<(),Error> {
+  let stk=th.stk();
   let f = stk.tpop::<F>().map_err(p_err("proc"))?;
   match &f {
     F::Bif(nm,d,_) => {
@@ -40,4 +40,24 @@ pub fn doc(stk:&mut Vstack) -> Result<(),Error> {
 
   stk.push(f);
   Ok(())
+}
+
+pub fn print(th:&mut Thread) -> Result<(),Error> {
+  th.print();
+  Ok(())
+}
+
+pub fn do_file(th:&mut Thread) -> Result<(),Error> {
+  use std::sync::Arc;
+  let path = th.stk().tpop::<Arc<str>>().map_err(p_err("path"))?;
+  let path : &str = &path; //gotta do this for the as_ref trait to kick in
+  let d = th.dict();
+  match crate::parser::load_file(path,d) {
+    Ok(f) => f.run(th),
+    Err(e) => {
+      println!("--file load error--");
+      println!("{e}");
+      Err(Error::Internal("file load error"))
+    }
+  }
 }

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -3,7 +3,11 @@ use std::{
   sync::Arc
 };
 
-use crate::{F,V,bifs};
+use crate::{
+  F,
+  V,
+  bifs
+};
 
 #[derive(Default)]
 pub struct Scope {

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
 use crate::{
-  Vstack,
   V,
+  Thread,
   bifs::Error as BifError
 };
 
-pub type BifPtr = fn(&mut Vstack) -> Result<(),BifError>;
+pub type BifPtr = fn(&mut Thread) -> Result<(),BifError>;
 
 #[derive(Debug,Clone)]
 pub enum F {
@@ -37,18 +37,18 @@ impl PartialEq for F {
 }
 
 impl F {
-  pub fn run(&self,stk:&mut Vstack) -> Result<(),BifError> {
+  pub fn run(&self,th:&mut Thread) -> Result<(),BifError> {
     match self {
-      Self::Bif(_,_,f) => f(stk),
+      Self::Bif(_,_,f) => f(th),
 
       Self::Def(_,arc) => {
         for v in arc.iter() {
           match v {
             V::C(f) => {
-              f.run(stk)?;
+              f.run(th)?;
             }
             x => {
-              stk.push(x.clone())
+              th.push_val(x.clone());
             }
           };
         }
@@ -60,10 +60,10 @@ impl F {
         for v in arc.iter() {
           match v {
             V::C(f) => {
-              f.run(stk)?;
+              f.run(th)?;
             }
             x => {
-              stk.push(x.clone())
+              th.push_val(x.clone())
             }
           };
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,23 +11,24 @@ mod parser;
 
 mod bifs;
 mod vm;
-use vm::VM;
+use vm::Thread;
 
 fn main() -> Result<(),Box<dyn std::error::Error>> {
-  run_repl();
+  run_repl()?;
   Ok(())
 }
 
-fn run_repl() {
+fn run_repl() -> Result<(),Box<dyn std::error::Error>> {
   let mut buff = String::new();
   let stdin = std::io::stdin();
-  let mut vm = VM::default();
+  let mut dict = Dict::default();
   let mut repl = parser::Repl::default();
+  let mut vm = Thread::as_list(&mut dict);
 
   loop {
     if stdin.read_line(&mut buff).is_err() {
       println!("bye");
-      return
+      return Ok(());
     }
 
     match repl.buff(&mut vm,&mut buff) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,13 @@
 use crate::{
-  VM,
-  vm::Error as VMErr,
+  V,
+  F,
+  Dict,
+  vm::{
+    Thread,
+    Error as VMErr,
+  },
   tokens::{
+    Token as T,
     St,
     Scanner,
     Error as TokErr
@@ -15,7 +21,7 @@ pub struct Repl {
 }
 
 impl Repl {
-  pub fn buff(&mut self,vm:&mut VM,buff:&mut String) -> Result<(),Error> {
+  pub fn buff(&mut self,vm:&mut Thread,buff:&mut String) -> Result<(),Error> {
     let input = &buff[..];
     let mut lx = Scanner::resume(input,self.pos,self.st);
 
@@ -38,7 +44,7 @@ impl Repl {
         }
       };
 
-      match vm.push_token(tk) {
+      match push_token(vm,tk) {
         Ok(()) => (),
         Err(e) => {
           self.st = St::Base;
@@ -50,8 +56,92 @@ impl Repl {
     }
   }
 }
-#[derive(Debug,Copy,Clone)]
+
+pub fn load_file<P:AsRef<std::path::Path>>(p:P,dict:&mut Dict) -> Result<F,Error> {
+  let f = std::fs::read_to_string(p).map_err(Error::Fs)?;
+  let mut vm = Thread::as_def(dict);
+  let mut lx = Scanner::resume(&f[..],0,St::Base);
+
+  let th = loop {
+    let tk = match lx.eat() {
+      Ok(tk) => tk,
+      Err(TokErr::Done) => {
+        break vm; 
+      },
+      Err(e) => {
+        let (_,comp,pos) = lx.done();
+        return Err(Error::FileSrc(e,comp,comp+pos));
+      }
+    };
+
+    match push_token(&mut vm,tk) {
+      Ok(()) => (),
+      Err(e) => {
+        let (_,comp,pos) = lx.done();
+        return Err(Error::FileExec(e,comp,comp+pos));
+      }
+    };
+  };
+
+  let vf = th.into_function().map_err(Error::FileEnd)?;
+
+  Ok(vf)
+}
+
+fn push_token(vm:&mut Thread,tk:T) -> Result<(),VMErr> {
+  let res = match tk {
+    T::OpenParen => {
+      vm.start_def();
+      Ok(())
+    },
+    
+    T::CloseParen => vm.end_def(None),
+    T::CloseDef(nm) => vm.end_def(Some(nm)),
+
+    T::OpenBracket => {
+      vm.start_list();
+      Ok(())
+    },
+    T::CloseBracket => vm.end_list(),
+
+    T::True => { 
+      vm.push_val(V::B(true));
+      Ok(())
+    },
+    T::False => {
+      vm.push_val(V::B(false)); 
+      Ok(())
+    },
+    T::I(i) =>{ 
+      vm.push_val(V::I(i)); 
+      Ok(())
+    },
+    T::Z(z) =>{ 
+      vm.push_val(V::Z(z));
+      Ok(())
+    },
+    T::Str(s) => {
+      vm.push_val(V::Str(s.into()));
+      Ok(())
+    }
+
+    T::Word(nm) => vm.word(nm),
+    T::QWord(nm) => vm.quote(nm)
+  };
+
+  if res.is_err() {
+    vm.drop_modes();
+  }
+
+  res
+}
+
+#[derive(Debug)]
 pub enum Error {
+  Fs(std::io::Error),
+  FileSrc(TokErr,usize,usize),
+  FileExec(VMErr,usize,usize),
+  FileEnd(VMErr),
   Scanner(TokErr),
   Exec(VMErr)
 }
@@ -59,8 +149,12 @@ pub enum Error {
 impl std::fmt::Display for Error {
   fn fmt(&self,f: &mut std::fmt::Formatter) -> Result<(),std::fmt::Error> {
     match self {
+      Self::FileSrc(x,s,e) => write!(f,"scan error in file pos: {s}-{e} : {x}"),
+      Self::FileExec(x,s,e) => write!(f,"error executing tokens in file pos {s}-{e} : {x}"),
+      Self::FileEnd(x) => write!(f,"error executing tokens at end of file: {x}"),
       Self::Scanner(e) => write!(f,"error while scanning tokens {e}"),
       Self::Exec(e) => write!(f,"error in vm execution {e}"),
+      Self::Fs(e)=> write!(f,"error reading file: {e}"),
     }
   }
 }

--- a/src/values.rs
+++ b/src/values.rs
@@ -97,3 +97,4 @@ vtraits!{Arc<[V]>,L,"list"}
 vtraits!{i64,I,"int"}
 vtraits!{F,F,"function"}
 vtraits!{bool,B,"bool"}
+vtraits!{Arc<str>,Str,"string"}


### PR DESCRIPTION
a pretty major change, moves the vm to a model where the dictionary is passed by ref, and "driven" by the tokenizer (i.e. it doesn't know what tokens are) moves the functions to operate over the whole thread, meaning they have access to both the stack and the dictionary so they can do things like define functions, load files, etc. And, as the name implies, cleans up some more error handling